### PR TITLE
chore(security): fix CVEs (2026-05-12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
     "packages": {
         "": {
             "devDependencies": {
-                "@tailwindcss/vite": "^4.2.4",
-                "axios": "^1.15.2",
+                "@tailwindcss/vite": "^4.3.0",
+                "axios": "^1.16.0",
                 "concurrently": "^9.2.1",
                 "laravel-vite-plugin": "^1.3.0",
-                "tailwindcss": "^4.2.4",
+                "tailwindcss": "^4.3.0",
                 "vite": "^6.4.2"
             }
         },
@@ -856,49 +856,49 @@
             ]
         },
         "node_modules/@tailwindcss/node": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-            "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+            "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.5",
-                "enhanced-resolve": "^5.19.0",
+                "enhanced-resolve": "^5.21.0",
                 "jiti": "^2.6.1",
                 "lightningcss": "1.32.0",
                 "magic-string": "^0.30.21",
                 "source-map-js": "^1.2.1",
-                "tailwindcss": "4.2.4"
+                "tailwindcss": "4.3.0"
             }
         },
         "node_modules/@tailwindcss/oxide": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-            "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+            "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 20"
             },
             "optionalDependencies": {
-                "@tailwindcss/oxide-android-arm64": "4.2.4",
-                "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-                "@tailwindcss/oxide-darwin-x64": "4.2.4",
-                "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-                "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-                "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-                "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-                "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-                "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-                "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-                "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+                "@tailwindcss/oxide-android-arm64": "4.3.0",
+                "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+                "@tailwindcss/oxide-darwin-x64": "4.3.0",
+                "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+                "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+                "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
             }
         },
         "node_modules/@tailwindcss/oxide-android-arm64": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-            "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+            "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
             "cpu": [
                 "arm64"
             ],
@@ -913,9 +913,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-arm64": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-            "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+            "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
             "cpu": [
                 "arm64"
             ],
@@ -930,9 +930,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-x64": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-            "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+            "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
             "cpu": [
                 "x64"
             ],
@@ -947,9 +947,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-freebsd-x64": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-            "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+            "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
             "cpu": [
                 "x64"
             ],
@@ -964,9 +964,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-            "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+            "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
             "cpu": [
                 "arm"
             ],
@@ -981,9 +981,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-            "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+            "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
             "cpu": [
                 "arm64"
             ],
@@ -998,9 +998,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-            "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+            "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1015,9 +1015,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-            "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+            "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
             "cpu": [
                 "x64"
             ],
@@ -1032,9 +1032,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-            "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+            "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
             "cpu": [
                 "x64"
             ],
@@ -1049,9 +1049,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-            "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+            "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
             "bundleDependencies": [
                 "@napi-rs/wasm-runtime",
                 "@emnapi/core",
@@ -1067,10 +1067,10 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.8.1",
-                "@emnapi/runtime": "^1.8.1",
-                "@emnapi/wasi-threads": "^1.1.0",
-                "@napi-rs/wasm-runtime": "^1.1.1",
+                "@emnapi/core": "^1.10.0",
+                "@emnapi/runtime": "^1.10.0",
+                "@emnapi/wasi-threads": "^1.2.1",
+                "@napi-rs/wasm-runtime": "^1.1.4",
                 "@tybys/wasm-util": "^0.10.1",
                 "tslib": "^2.8.1"
             },
@@ -1079,9 +1079,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-            "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+            "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1096,9 +1096,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-            "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+            "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
             "cpu": [
                 "x64"
             ],
@@ -1113,15 +1113,15 @@
             }
         },
         "node_modules/@tailwindcss/vite": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
-            "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+            "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@tailwindcss/node": "4.2.4",
-                "@tailwindcss/oxide": "4.2.4",
-                "tailwindcss": "4.2.4"
+                "@tailwindcss/node": "4.3.0",
+                "@tailwindcss/oxide": "4.3.0",
+                "tailwindcss": "4.3.0"
             },
             "peerDependencies": {
                 "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -1168,13 +1168,13 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }
@@ -1339,9 +1339,9 @@
             "license": "MIT"
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.21.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-            "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+            "version": "5.21.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
+            "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2210,9 +2210,9 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-            "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+            "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
         "dev": "vite"
     },
     "devDependencies": {
-        "@tailwindcss/vite": "^4.2.4",
-        "axios": "^1.15.2",
+        "@tailwindcss/vite": "^4.3.0",
+        "axios": "^1.16.0",
         "concurrently": "^9.2.1",
         "laravel-vite-plugin": "^1.3.0",
-        "tailwindcss": "^4.2.4",
+        "tailwindcss": "^4.3.0",
         "vite": "^6.4.2"
     }
 }


### PR DESCRIPTION
## Security & dependency fixes — 2026-05-12

### Dependabot version bumps

| Package | From | To | Summary |
|---------|------|----|---------|
| tailwindcss | 4.2.4 | 4.3.0 | Minor bump |
| @tailwindcss/vite | 4.2.4 | 4.3.0 | Minor bump |
| axios | 1.15.2 | 1.16.0 | Minor bump |

> Major bumps (vite 6→8, laravel-vite-plugin 1→3) listed in CVE manual review report.
